### PR TITLE
Check multicall return value differently

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -124,9 +124,12 @@ export async function ethCall(rawData, { id, web3, rpcUrl, block, multicallAddre
       })
     });
     const content = await rawResponse.json();
+
+    // Note: sometimes if we don't toString content, it will be falsy and it will throw, even though it's valid
     if (!content?.toString() || !content.result) {
       throw new Error('Multicall received an empty response. Check your call configuration for errors.');
     }
+
     return content.result;
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -124,7 +124,7 @@ export async function ethCall(rawData, { id, web3, rpcUrl, block, multicallAddre
       })
     });
     const content = await rawResponse.json();
-    if (!content || !content.result) {
+    if (!content?.toString() || !content.result) {
       throw new Error('Multicall received an empty response. Check your call configuration for errors.');
     }
     return content.result;


### PR DESCRIPTION
Sometimes content is only present if we call toString on it.